### PR TITLE
Track referer if package was not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,18 +44,16 @@ server.route({
 
       var cachedUrl = cache.get(cacheKey);
       if (cachedUrl) {
-        console.log('Get cache entry %s', cachedUrl);
         return resolvedHandler(cachedUrl);
       }
-
-      console.log('Hit %s registry for %s', type, pkg);
 
       resolver(type, pkg, function(err, url) {
 
         if (err && err.code === 404) {
           insight.sendEvent('package_not_found', {
             registry: type,
-            package: pkg
+            package: pkg,
+            referer: request.headers.referer
           });
           return reply({error: 'Package not found'}).code(404);
         }


### PR DESCRIPTION
In the last few days I saw some unresolved package like `assets/css/*.css` or `&includePaths[]=` in the logs. I don't know what's going on there, so I decided to track the request referer to get some context. The stored data are used only to improve the github-linker and will be not passed on to any third party.