### PR TITLE
Attempt to resolve paths that point within packages

### DIFF
--- a/src/resolver/npm.js
+++ b/src/resolver/npm.js
@@ -5,7 +5,11 @@ var got = require('got');
 var findRepositoryUrl = require('../utils/find-repository-url');
 var registryUrl = 'https://registry.npmjs.org/%s';
 
-module.exports = function (pkg, cb) {
+module.exports = function (path, cb) {
+
+  var components = path.split('/');
+  var pkg = components[0];
+  var innerPath = components.slice(1).join('/');
 
 	got(util.format(registryUrl, pkg), {json: true}, function (err, json) {
     var url = null;
@@ -15,6 +19,9 @@ module.exports = function (pkg, cb) {
 
     if (json) {
       url = findRepositoryUrl(json);
+      if (url && innerPath) {
+        url += '/blob/master/' + innerPath
+      }
     }
 
     if (!url) {


### PR DESCRIPTION
Together with github-linker/core#24, this will allow
github-linker/chrome-extension to resolve require calls like:

```javascript
require.resolve('readable-stream/passthrough.js');
```

For example:

    node index.js
    Server running at: http://localhost:3000
    resolved { registry: 'npm',
      package: 'readable-stream/passthrough.js',
      url: 'https://github.com/nodejs/readable-stream/blob/master/passthrough.js' }