### PR TITLE
Packagist fallback for Composer

### DIFF
--- a/src/resolver/composer.js
+++ b/src/resolver/composer.js
@@ -9,8 +9,12 @@ module.exports = function (pkg, cb) {
 
   got(util.format(registryUrl, pkg), {json: true}, function (err, json) {
     var url = '';
-
     if (err) {
+      if (err.code === 404) {
+        url = 'https://packagist.org/packages/' + pkg;
+        return cb(null, url);
+      }
+
       return cb(err);
     }
 

--- a/test/resolver-composer.spec.js
+++ b/test/resolver-composer.spec.js
@@ -57,19 +57,16 @@ describe('composer resolver', function() {
     assert.equal(callbackStub.args[0][1], 'https://linkerhub.com/pale-ale-beer');
   });
 
-  it('returns empty string when package was not resolvable', function() {
+  it('returns packagist.org url when package was not resolvable', function() {
     var callbackStub = this.sandbox.stub();
-    var response = {
-      package: {
-        name: 'pale-ale-beer',
-        repository: 'https://linkerhub.com/pale-ale-beer'
-      }
+    var err = {
+      code: 404
     };
     composerResolver('pale-ale-beer', callbackStub);
-    this.githubUrlStub.returns('');
-    this.gotStub.callArgWith(2, null, response);
+    this.gotStub.callArgWith(2, err);
 
-    assert.equal(callbackStub.args[0][1], '');
+    composerResolver('pale-ale-beer', callbackStub);
+    assert.equal(callbackStub.args[0][1], 'https://packagist.org/packages/pale-ale-beer');
   });
 
   it('returns empty string when response was invalid', function() {


### PR DESCRIPTION
If the composer lookup fails, link to `https://packagist.org/packages/{vendor}/{client}`